### PR TITLE
Fix compile error on MSVC 2017

### DIFF
--- a/jpgd.cpp
+++ b/jpgd.cpp
@@ -2126,7 +2126,7 @@ namespace jpgd {
 
 	int jpeg_decoder::decode_next_mcu_row()
 	{
-		if (setjmp(m_jmp_state))
+		if (::setjmp(m_jmp_state))
 			return JPGD_FAILED;
 
 		const bool chroma_y_filtering = ((m_flags & cFlagBoxChromaFiltering) == 0) && ((m_scan_type == JPGD_YH2V2) || (m_scan_type == JPGD_YH1V2));
@@ -3042,7 +3042,7 @@ namespace jpgd {
 
 	jpeg_decoder::jpeg_decoder(jpeg_decoder_stream* pStream, uint32_t flags)
 	{
-		if (setjmp(m_jmp_state))
+		if (::setjmp(m_jmp_state))
 			return;
 		decode_init(pStream, flags);
 	}
@@ -3055,7 +3055,7 @@ namespace jpgd {
 		if (m_error_code)
 			return JPGD_FAILED;
 
-		if (setjmp(m_jmp_state))
+		if (::setjmp(m_jmp_state))
 			return JPGD_FAILED;
 
 		decode_start();


### PR DESCRIPTION
MSVC 2017 was giving errors about those `setjmp()` calls:
```
jpgd.cpp(2129): error C2668: 'jpgd::_setjmp': ambiguous call to overloaded function
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\intrin.h(920): note: could be 'int jpgd::_setjmp(_JBTYPE [])'
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\setjmp.h(157): note: or       'int _setjmp(_JBTYPE [])' [found using argument-dependent lookup]
jpgd.cpp(2129): note: while trying to match the argument list '(jmp_buf)'
jpgd.cpp(3045): error C2668: 'jpgd::_setjmp': ambiguous call to overloaded function
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\intrin.h(920): note: could be 'int jpgd::_setjmp(_JBTYPE [])'
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\setjmp.h(157): note: or       'int _setjmp(_JBTYPE [])' [found using argument-dependent lookup]
jpgd.cpp(3045): note: while trying to match the argument list '(jmp_buf)'
jpgd.cpp(3058): error C2668: 'jpgd::_setjmp': ambiguous call to overloaded function
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\intrin.h(920): note: could be 'int jpgd::_setjmp(_JBTYPE [])'
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\setjmp.h(157): note: or       'int _setjmp(_JBTYPE [])' [found using argument-dependent lookup]
jpgd.cpp(3058): note: while trying to match the argument list '(jmp_buf)'
```

This PR fixes them by unambiguating via the scope resolution operator.

BTW, greetings from the Godot team! I found this after Godot was upgraded to the last version of this library.