### PR TITLE
Fix detection of SSE2 with Visual Studio

### DIFF
--- a/jpgd.cpp
+++ b/jpgd.cpp
@@ -37,16 +37,14 @@
 
 #ifndef JPGD_USE_SSE2
 
-	#if defined(__GNUC__) 
-
-		#if (defined(__x86_64__) || defined(_M_X64)) 
-			#if defined(__SSE2__)
-				#define JPGD_USE_SSE2 (1)
-			#endif
+	#if defined(__GNUC__)
+		#if defined(__SSE2__)
+			#define JPGD_USE_SSE2 (1)
 		#endif
-
-	#else
-		#define JPGD_USE_SSE2 (1)
+	#elif defined(_MSC_VER)
+		#if defined(_M_X64)
+			#define JPGD_USE_SSE2 (1)
+		#endif
 	#endif
 
 #endif


### PR DESCRIPTION
The previous code assumed that SSE2 is available when building with
Visual Studio, but that's not accurate on ARM with UWP.

SSE2 could also be enabled on x86 if `_M_IX86_FP == 2`, but it requires
checking first that it's not actually set to 2 for AVX, AVX2 or AVX512
(see https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019),
so I left it out for this quick fix.