### PR TITLE
Making Sure half_image_[x | y]_size is not negative.

### DIFF
--- a/jpgd.cpp
+++ b/jpgd.cpp
@@ -1669,7 +1669,7 @@ namespace jpgd {
 		int row = m_max_mcu_y_size - m_mcu_lines_left;
 		uint8* d0 = m_pScan_line_0;
 
-		const int half_image_x_size = (m_image_x_size >> 1) - 1;
+		const int half_image_x_size = (m_image_x_size == 1) ? 0 : (m_image_x_size >> 1) - 1;
 		const int row_x8 = row * 8;
 
 		for (int x = 0; x < m_image_x_size; x++)
@@ -1762,7 +1762,7 @@ namespace jpgd {
 		int y = m_image_y_size - m_total_lines_left;
 		int row = y & 15;
 
-		const int half_image_y_size = (m_image_y_size >> 1) - 1;
+		const int half_image_y_size = (m_image_y_size == 1) ? 0 : (m_image_y_size >> 1) - 1;
 
 		uint8* d0 = m_pScan_line_0;
 
@@ -1891,7 +1891,7 @@ namespace jpgd {
 		int y = m_image_y_size - m_total_lines_left;
 		int row = y & 15;
 
-		const int half_image_y_size = (m_image_y_size >> 1) - 1;
+		const int half_image_y_size = (m_image_y_size == 1) ? 0 : (m_image_y_size >> 1) - 1;
 
 		uint8* d0 = m_pScan_line_0;
 
@@ -1915,7 +1915,7 @@ namespace jpgd {
 		const int y0_base = (c_y0 & 7) * 8 + 256;
 		const int y1_base = (c_y1 & 7) * 8 + 256;
 
-		const int half_image_x_size = (m_image_x_size >> 1) - 1;
+		const int half_image_x_size = (m_image_y_size == 1) ? 0 : (m_image_x_size >> 1) - 1;
 
 		static const uint8_t s_muls[2][2][4] =
 		{


### PR DESCRIPTION
without this check when an 1 x 1 or 1 x X or X x 1 Pixel Image using sub-sampling. the half_image_size would be -1 which would result in a crash on future steps.
Fixed : https://github.com/godotengine/godot/issues/42363 Caused by this Bug.