### PR TITLE
jpge.cpp: Remove #include <malloc.h>

### DIFF
--- a/jpge.cpp
+++ b/jpge.cpp
@@ -32,7 +32,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #define JPGE_MAX(a,b) (((a)>(b))?(a):(b))
 #define JPGE_MIN(a,b) (((a)<(b))?(a):(b))


### PR DESCRIPTION
`malloc.h` is deprecated and does not exist on macOS. `stdlib.h` provides malloc.